### PR TITLE
Plot qcbm history

### DIFF
--- a/examples/optimize-qcbm-circuit.yaml
+++ b/examples/optimize-qcbm-circuit.yaml
@@ -83,7 +83,7 @@ spec:
           - distance-measure-specs: "{'module_name': 'zquantum.core.bitstring_distribution', 'function_name': 'compute_clipped_negative_log_likelihood'}"
           - distance-measure-parameters: "{'epsilon': 1e-6}"
           - backend-specs: "{'module_name': 'qeforest.simulator', 'function_name': 'ForestSimulator', 'device_name': 'wavefunction-simulator'}"
-          - optimizer-specs: "{'module_name': 'zquantum.optimizers.cma_es_optimizer', 'function_name': 'CMAESOptimizer', 'options': {'popsize': 5, 'sigma_0': 0.1, 'tolx': 1e-6}}"
+          - optimizer-specs: "{'module_name': 'zquantum.optimizers.cma_es_optimizer', 'function_name': 'CMAESOptimizer', 'options': {'popsize': 5, 'sigma_0': 0.1, 'tolx': 1e-6, 'seed': {{workflow.parameters.seed}}}}"
           # - optimizer-specs: "{'module_name': 'zquantum.optimizers.scipy_optimizer', 'function_name': 'ScipyOptimizer', 'method': 'L-BFGS-B'}"
           - resources: [z-quantum-core, qe-openfermion, z-quantum-optimizers, qe-forest, z-quantum-qcbm]
           - memory: 2048Mi

--- a/examples/plot_qcbm_opt_history.py
+++ b/examples/plot_qcbm_opt_history.py
@@ -126,7 +126,7 @@ def animate(i):
 
     ax2.clear()
     ax2.set(xlabel="Bitstring", ylabel="Measured Probability")
-    ax2.set_ylim([0, np.max(target_distribution) + 0.1])
+    ax2.set_ylim([0, np.max(target_distribution) + 0.05])
     ax2.bar(ordered_bitstrings, bitstring_distributions[i], facecolor="green")
     ax2.bar(
         ordered_bitstrings,

--- a/examples/plot_qcbm_opt_history.py
+++ b/examples/plot_qcbm_opt_history.py
@@ -23,7 +23,7 @@ def get_ordered_list_of_bitstrings(num_qubits):
 
 
 # Insert the path to your JSON file here
-with open("./examples/qcbm-example.json") as f:
+with open("./qcbm-example.json") as f:
     data = json.load(f)
 
 # Extract target/measured bitstring distribution and distance measure values.
@@ -35,6 +35,10 @@ target_distribution = []
 current_minimum = 100000
 for step_id in data:
     step = data[step_id]
+    # n_qubits = int(step["inputParam:ansatz-specs"])
+    print(step["inputParam:ansatz-specs"])
+
+    # "inputParam:ansatz-specs":"{'module_name': 'zquantum.qcbm.ansatz', 'function_name': 'QCBMAnsatz', 'number_of_layers': 1, 'number_of_qubits': 4,
     ordered_bitstrings = get_ordered_list_of_bitstrings(
         int(step["inputParam:n-qubits"])
     )

--- a/examples/plot_qcbm_opt_history.py
+++ b/examples/plot_qcbm_opt_history.py
@@ -126,7 +126,7 @@ def animate(i):
 
     ax2.clear()
     ax2.set(xlabel="Bitstring", ylabel="Measured Probability")
-    ax2.set_ylim([0, np.max(bitstring_distributions)])
+    ax2.set_ylim([0, np.max(target_distribution) + 0.1])
     ax2.bar(ordered_bitstrings, bitstring_distributions[i], facecolor="green")
     ax2.bar(
         ordered_bitstrings,

--- a/examples/plot_qcbm_opt_history.py
+++ b/examples/plot_qcbm_opt_history.py
@@ -35,15 +35,20 @@ target_distribution = []
 current_minimum = 100000
 for step_id in data:
     step = data[step_id]
-    # n_qubits = int(step["inputParam:ansatz-specs"])
-    print(step["inputParam:ansatz-specs"])
-
-    # "inputParam:ansatz-specs":"{'module_name': 'zquantum.qcbm.ansatz', 'function_name': 'QCBMAnsatz', 'number_of_layers': 1, 'number_of_qubits': 4,
-    ordered_bitstrings = get_ordered_list_of_bitstrings(
-        int(step["inputParam:n-qubits"])
-    )
+    if step["class"] == "generate-random-ansatz-params":
+        number_of_qubits = int(
+            eval(step["inputParam:ansatz-specs"])["number_of_qubits"]
+        )
+    ordered_bitstrings = get_ordered_list_of_bitstrings(number_of_qubits)
     if step["class"] == "generate-bars-and-stripes-target-distribution":
         target_distribution = []
+        for key in ordered_bitstrings:
+            try:
+                target_distribution.append(
+                    step["distribution"]["bitstring_distribution"][key]
+                )
+            except:
+                target_distribution.append(0)
         exact_distance_value = entropy(target_distribution)
     elif step["class"] == "optimize-variational-qcbm-circuit":
         for evaluation in step["optimization-results"]["history"]:
@@ -103,7 +108,7 @@ def animate(i):
         xlabel="Evaluation Index",
         ylabel="Clipped negative log-likelihood cost function",
     )
-    ax1.set_ylim([exact_distance_value - 0.1, exact_distance_value + 1])
+    ax1.set_ylim([exact_distance_value - 0.1, exact_distance_value + 1.5])
     ax1.scatter(
         evals, plotted_distances, color="green", linewidths=line_widths, marker="."
     )
@@ -121,7 +126,7 @@ def animate(i):
 
     ax2.clear()
     ax2.set(xlabel="Bitstring", ylabel="Measured Probability")
-    ax2.set_ylim([0, np.max(bitstring_distributions) + 0.1])
+    ax2.set_ylim([0, np.max(bitstring_distributions)])
     ax2.bar(ordered_bitstrings, bitstring_distributions[i], facecolor="green")
     ax2.bar(
         ordered_bitstrings,

--- a/examples/plot_qcbm_opt_history.py
+++ b/examples/plot_qcbm_opt_history.py
@@ -30,7 +30,6 @@ with open("./qcbm-example.json") as f:
 distances = []
 minimum_distances = []
 bitstring_distributions = []
-target_distribution = []
 
 current_minimum = 100000
 for step_id in data:


### PR DESCRIPTION
This PR implements the following changes: 
- Adding `seed` specification to CMA-ES options for reproducibility purpose
- Adding expected value of clipped log likelihood in the plotting script and adjusting `ylim` accordingly 
- Adding the target distribution to the plots 