### PR TITLE
ZQS-670 make tests reproducible

### DIFF
--- a/tests/zquantum/qcbm/target_thermal_states_test.py
+++ b/tests/zquantum/qcbm/target_thermal_states_test.py
@@ -1,7 +1,8 @@
+import random
 import unittest
 import numpy as np
+import numpy.testing
 from zquantum.core.utils import dec2bin, convert_tuples_to_bitstrings
-from zquantum.core.bitstring_distribution import BitstringDistribution
 from zquantum.core.bitstring_distribution.distance_measures.mmd import compute_mmd
 from zquantum.qcbm.target_thermal_states import (
     convert_integer_to_ising_bitstring,
@@ -135,7 +136,9 @@ class TestThermalTarget(unittest.TestCase):
         n_samples = 5000
         n_spins = 2
         temperature = 0.85
-        np.random.seed(SEED)
+        np.random.seed(SEED)  # needed by our samplers
+        random.seed(SEED)  # needed to make lea reproducible
+
         external_fields = np.random.rand(n_spins)
         two_body_couplings = np.random.rand(n_spins, n_spins)
         hamiltonian_parameters = [external_fields, two_body_couplings]
@@ -165,17 +168,16 @@ class TestThermalTarget(unittest.TestCase):
         n_spins = 4
         temperature = 1.0
         distance_measure_parameters = {"sigma": 1.0}
-        np.random.seed(SEED)
+        np.random.seed(SEED)  # needed by our samplers
+        random.seed(SEED)  # needed to make lea reproducible
+
         external_fields = np.random.rand(n_spins)
         two_body_couplings = np.random.rand(n_spins, n_spins)
         hamiltonian_parameters = [external_fields, two_body_couplings]
-        np.random.seed(SEED)
+
         actual = get_thermal_target_bitstring_distribution(
-            n_spins,
-            temperature,
-            hamiltonian_parameters,
+            n_spins, temperature, hamiltonian_parameters
         )
-        np.random.seed(SEED)
         model = get_thermal_sampled_distribution(
             n_samples, n_spins, temperature, hamiltonian_parameters
         )
@@ -191,7 +193,9 @@ class TestThermalTarget(unittest.TestCase):
         n_samples = 10000
         n_spins = 4
         temperature = 1.0
-        np.random.seed(SEED)
+        np.random.seed(SEED)  # needed by our samplers
+        random.seed(SEED)  # needed to make lea reproducible
+
         external_fields = np.random.rand(n_spins)
         two_body_couplings = np.random.rand(n_spins, n_spins)
         hamiltonian_parameters = [external_fields, two_body_couplings]


### PR DESCRIPTION
Fixes an issue where running `target_thermal_states_test` might fail once in a while because of changed results. This was caused by using [lea's random](https://github.com/zapatacomputing/z-quantum-core/blob/1085df5e40e78c20ea32e290ea8642e8090ba1b2/src/python/zquantum/core/utils.py#L195) underneath. We've been setting `numpy.random` state, but lea uses stdlib's `random` state instead.

This can be tested by running:
```
repeat 20 pytest tests/zquantum/qcbm/target_thermal_states_test.py -v
```

Before this PR, the above command was expected to fail ~ 4/20 times. After, it's passing 20/20.