### PR TITLE
ZQS 673 New cost function protocols + use callable gradient arg

### DIFF
--- a/src/python/zquantum/qcbm/cost_function.py
+++ b/src/python/zquantum/qcbm/cost_function.py
@@ -1,4 +1,5 @@
 import warnings
+from numbers import Number
 from typing import Callable
 
 import numpy as np
@@ -14,14 +15,18 @@ from zquantum.core.interfaces.functions import StoreArtifact, function_with_grad
 from zquantum.core.utils import ValueEstimate
 
 
+GradientFactory = Callable[[Callable], Callable[[np.ndarray], np.ndarray]]
+DistanceMeasure = Callable[..., Number]
+
+
 def create_QCBM_cost_function(
     ansatz: Ansatz,
     backend: QuantumBackend,
     n_samples: int,
-    distance_measure: Callable,
+    distance_measure: DistanceMeasure,
     distance_measure_parameters: dict,
     target_bitstring_distribution: BitstringDistribution,
-    gradient_function: Callable = finite_differences_gradient,
+    gradient_function: GradientFactory = finite_differences_gradient,
 ) -> CostFunction:
     """Cost function used for evaluating QCBM.
 
@@ -55,7 +60,7 @@ def QCBMCostFunction(
     ansatz: Ansatz,
     backend: QuantumBackend,
     n_samples: int,
-    distance_measure: Callable,
+    distance_measure: DistanceMeasure,
     distance_measure_parameters: dict,
     target_bitstring_distribution: BitstringDistribution,
     gradient_type: str = "finite_difference",
@@ -107,7 +112,7 @@ def _create_QCBM_cost_function(
     ansatz: Ansatz,
     backend: QuantumBackend,
     n_samples: int,
-    distance_measure: Callable,
+    distance_measure: DistanceMeasure,
     distance_measure_parameters: dict,
     target_bitstring_distribution: BitstringDistribution,
 ):

--- a/src/python/zquantum/qcbm/cost_function.py
+++ b/src/python/zquantum/qcbm/cost_function.py
@@ -13,6 +13,43 @@ from zquantum.core.interfaces.functions import StoreArtifact, function_with_grad
 from zquantum.core.utils import ValueEstimate
 
 
+def create_QCBM_cost_function(
+    ansatz: Ansatz,
+    backend: QuantumBackend,
+    n_samples: int,
+    distance_measure: Callable,
+    distance_measure_parameters: dict,
+    target_bitstring_distribution: BitstringDistribution,
+    gradient_function: Callable = finite_differences_gradient,
+) -> CostFunction:
+    """Cost function used for evaluating QCBM.
+
+    Args:
+        ansatz: the ansatz used to construct the variational circuits
+        backend: backend used for QCBM evaluation
+        distance_measure: function used to calculate the distance measure
+        distance_measure_parameters: dictionary containing the relevant parameters for the chosen distance measure
+        target_bitstring_distribution: bistring distribution which QCBM aims to learn
+        gradient_function: a function which returns a function used to compute the gradient of the cost function
+            (see zquantum.core.gradients.finite_differences_gradient for reference)
+
+    Returns:
+        Callable CostFunction object that evaluates the parametrized circuit produced by the ansatz with the given
+        parameters and returns the distance between the produced bitstring distribution and the target distribution
+    """
+
+    cost_function = _create_QCBM_cost_function(
+        ansatz,
+        backend,
+        n_samples,
+        distance_measure,
+        distance_measure_parameters,
+        target_bitstring_distribution,
+    )
+
+    return function_with_gradient(cost_function, gradient_function(cost_function))
+
+
 def QCBMCostFunction(
     ansatz: Ansatz,
     backend: QuantumBackend,
@@ -26,18 +63,52 @@ def QCBMCostFunction(
     """Cost function used for evaluating QCBM.
 
     Args:
-        ansatz (zquantum.core.interfaces.ansatz.Ansatz): the ansatz used to construct the variational circuits
-        backend (zquantum.core.interfaces.backend.QuantumBackend): backend used for QCBM evaluation
-        distance_measure (callable): function used to calculate the distance measure
-        distance_measure_parameters (dict): dictionary containing the relevant parameters for the chosen distance measure
-        target_bitstring_distribution (zquantum.core.bitstring_distribution.BitstringDistribution): bistring distribution which QCBM aims to learn
-        gradient_type (str): parameter indicating which type of gradient should be used.
+        ansatz: the ansatz used to construct the variational circuits
+        backend: backend used for QCBM evaluation
+        distance_measure: function used to calculate the distance measure
+        distance_measure_parameters: dictionary containing the relevant parameters for the chosen distance measure
+        target_bitstring_distribution: bistring distribution which QCBM aims to learn
+        gradient_type: parameter indicating which type of gradient should be used.
 
     Returns:
-        Callable that evaluates the parametrized circuit produced by the ansatz with the given parameters and returns
-            the distance between the produced bitstring distribution and the target distribution
+        Callable CostFunction object that evaluates the parametrized circuit produced by the ansatz with the given
+        parameters and returns the distance between the produced bitstring distribution and the target distribution
     """
 
+    DeprecationWarning(
+        "QCBMCostFunction is deprecated in favour of create_QCBM_cost_function."
+    )
+
+    cost_function = _create_QCBM_cost_function(
+        ansatz,
+        backend,
+        n_samples,
+        distance_measure,
+        distance_measure_parameters,
+        target_bitstring_distribution,
+    )
+
+    if gradient_kwargs is None:
+        gradient_kwargs = {}
+
+    if gradient_type == "finite_difference":
+        cost_function = function_with_gradient(
+            cost_function, finite_differences_gradient(cost_function, **gradient_kwargs)
+        )
+    else:
+        raise RuntimeError("Unsupported gradient type: ", gradient_type)
+
+    return cost_function
+
+
+def _create_QCBM_cost_function(
+    ansatz: Ansatz,
+    backend: QuantumBackend,
+    n_samples: int,
+    distance_measure: Callable,
+    distance_measure_parameters: dict,
+    target_bitstring_distribution: BitstringDistribution,
+):
     assert (
         int(target_bitstring_distribution.get_qubits_number())
         == ansatz.number_of_qubits
@@ -70,15 +141,5 @@ def QCBMCostFunction(
             store_artifact("bitstring_distribution", distribution)
 
         return ValueEstimate(value)
-
-    if gradient_kwargs is None:
-        gradient_kwargs = {}
-
-    if gradient_type == "finite_difference":
-        cost_function = function_with_gradient(
-            cost_function, finite_differences_gradient(cost_function, **gradient_kwargs)
-        )
-    else:
-        raise RuntimeError("Unsupported gradient type: ", gradient_type)
 
     return cost_function

--- a/src/python/zquantum/qcbm/cost_function.py
+++ b/src/python/zquantum/qcbm/cost_function.py
@@ -83,7 +83,7 @@ def QCBMCostFunction(
 
     warnings.warn(
         "QCBMCostFunction is deprecated in favour of create_QCBM_cost_function.",
-        DeprecationWarning
+        DeprecationWarning,
     )
 
     cost_function = _create_QCBM_cost_function(

--- a/src/python/zquantum/qcbm/cost_function.py
+++ b/src/python/zquantum/qcbm/cost_function.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Callable
 
 import numpy as np
@@ -75,8 +76,9 @@ def QCBMCostFunction(
         parameters and returns the distance between the produced bitstring distribution and the target distribution
     """
 
-    DeprecationWarning(
-        "QCBMCostFunction is deprecated in favour of create_QCBM_cost_function."
+    warnings.warn(
+        "QCBMCostFunction is deprecated in favour of create_QCBM_cost_function.",
+        DeprecationWarning
     )
 
     cost_function = _create_QCBM_cost_function(

--- a/src/python/zquantum/qcbm/cost_function.py
+++ b/src/python/zquantum/qcbm/cost_function.py
@@ -1,14 +1,16 @@
-from zquantum.core.interfaces.functions import function_with_gradient, StoreArtifact
-from zquantum.core.interfaces.backend import QuantumBackend
-from zquantum.core.interfaces.ansatz import Ansatz
+from typing import Callable
+
+import numpy as np
 from zquantum.core.bitstring_distribution import (
     BitstringDistribution,
     evaluate_distribution_distance,
 )
-from zquantum.core.utils import ValueEstimate
 from zquantum.core.gradients import finite_differences_gradient
-from typing import Union, Callable
-import numpy as np
+from zquantum.core.interfaces.ansatz import Ansatz
+from zquantum.core.interfaces.backend import QuantumBackend
+from zquantum.core.interfaces.cost_function import CostFunction
+from zquantum.core.interfaces.functions import StoreArtifact, function_with_gradient
+from zquantum.core.utils import ValueEstimate
 
 
 def QCBMCostFunction(
@@ -20,7 +22,7 @@ def QCBMCostFunction(
     target_bitstring_distribution: BitstringDistribution,
     gradient_type: str = "finite_difference",
     gradient_kwargs: dict = None,
-):
+) -> CostFunction:
     """Cost function used for evaluating QCBM.
 
     Args:
@@ -71,7 +73,7 @@ def QCBMCostFunction(
 
     if gradient_kwargs is None:
         gradient_kwargs = {}
-        
+
     if gradient_type == "finite_difference":
         cost_function = function_with_gradient(
             cost_function, finite_differences_gradient(cost_function, **gradient_kwargs)

--- a/tests/zquantum/qcbm/cost_function_test.py
+++ b/tests/zquantum/qcbm/cost_function_test.py
@@ -1,185 +1,191 @@
-import unittest
-from zquantum.qcbm.cost_function import QCBMCostFunction
-from zquantum.qcbm.ansatz import QCBMAnsatz
+import numpy as np
+import pytest
 from zquantum.core.bitstring_distribution import (
     BitstringDistribution,
     compute_clipped_negative_log_likelihood,
     compute_mmd,
 )
-from zquantum.core.utils import create_object, ValueEstimate
+from zquantum.core.gradients import finite_differences_gradient
 from zquantum.core.history.recorder import recorder
-import numpy as np
+from zquantum.core.utils import ValueEstimate, create_object
+from zquantum.qcbm.ansatz import QCBMAnsatz
+from zquantum.qcbm.cost_function import QCBMCostFunction, create_QCBM_cost_function
 
-param_list = [
-    (compute_clipped_negative_log_likelihood, {"epsilon": 1e-6}),
-    (compute_mmd, {"sigma": 1}),
-]
+number_of_layers = 1
+number_of_qubits = 4
+topology = "all"
+ansatz = QCBMAnsatz(number_of_layers, number_of_qubits, topology)
+target_bitstring_distribution = BitstringDistribution(
+    {
+        "0000": 1.0,
+        "0001": 0.0,
+        "0010": 0.0,
+        "0011": 1.0,
+        "0100": 0.0,
+        "0101": 1.0,
+        "0110": 0.0,
+        "0111": 0.0,
+        "1000": 0.0,
+        "1001": 0.0,
+        "1010": 1.0,
+        "1011": 0.0,
+        "1100": 1.0,
+        "1101": 0.0,
+        "1110": 0.0,
+        "1111": 1.0,
+    }
+)
+
+backend = create_object(
+    {
+        "module_name": "zquantum.core.symbolic_simulator",
+        "function_name": "SymbolicSimulator",
+    }
+)
+
+n_samples = 1
 
 
-class TestQCBMCostFunction(unittest.TestCase):
-    def setUp(self):
-        number_of_layers = 1
-        number_of_qubits = 4
-        topology = "all"
-        self.ansatz = QCBMAnsatz(number_of_layers, number_of_qubits, topology)
-        self.target_bitstring_distribution = BitstringDistribution(
+class TestQCBMCostFunction:
+    @pytest.fixture(params=[QCBMCostFunction, create_QCBM_cost_function])
+    def cost_function_factory(self, request):
+        return request.param
+
+    @pytest.fixture(
+        params=[
             {
-                "0000": 1.0,
-                "0001": 0.0,
-                "0010": 0.0,
-                "0011": 1.0,
-                "0100": 0.0,
-                "0101": 1.0,
-                "0110": 0.0,
-                "0111": 0.0,
-                "1000": 0.0,
-                "1001": 0.0,
-                "1010": 1.0,
-                "1011": 0.0,
-                "1100": 1.0,
-                "1101": 0.0,
-                "1110": 0.0,
-                "1111": 1.0,
-            }
+                "distance_measure": compute_clipped_negative_log_likelihood,
+                "distance_measure_parameters": {"epsilon": 1e-6},
+            },
+            {
+                "distance_measure": compute_mmd,
+                "distance_measure_parameters": {"sigma": 1},
+            },
+        ]
+    )
+    def distance_measure_kwargs(self, request):
+        return request.param
+
+    def test_evaluate(self, cost_function_factory, distance_measure_kwargs):
+        # Given
+        cost_function = cost_function_factory(
+            ansatz,
+            backend,
+            n_samples,
+            **distance_measure_kwargs,
+            target_bitstring_distribution=target_bitstring_distribution,
         )
 
-        self.backend = create_object(
-            {
-                "module_name": "zquantum.core.symbolic_simulator",
-                "function_name": "SymbolicSimulator",
-            }
+        params = np.array([0, 0, 0, 0])
+
+        # When
+        value_estimate = cost_function(params)
+
+        # Then
+        assert type(value_estimate) == ValueEstimate
+        assert isinstance(value_estimate.value, (np.floating, float))
+
+    def test_evaluate_history(self, cost_function_factory, distance_measure_kwargs):
+        # Given
+        cost_function = cost_function_factory(
+            ansatz,
+            backend,
+            n_samples,
+            **distance_measure_kwargs,
+            target_bitstring_distribution=target_bitstring_distribution,
         )
 
-        self.gradient_types = ["finite_difference"]
-        self.n_samples = 1
+        cost_function = recorder(cost_function)
 
-    def test_evaluate(self):
-        for distance_meas, distance_measure_params in param_list:
-            with self.subTest():
-                # Given
-                self.distance_measure = distance_meas
-                distance_measure_parameters = distance_measure_params
+        params = np.array([0, 0, 0, 0])
 
-                cost_function = QCBMCostFunction(
-                    self.ansatz,
-                    self.backend,
-                    self.n_samples,
-                    self.distance_measure,
-                    distance_measure_parameters,
-                    self.target_bitstring_distribution,
+        # When
+        value_estimate = cost_function(params)
+        history = cost_function.history
+
+        # Then
+        assert pytest.approx(len(history), 1)
+        assert pytest.approx(
+            BitstringDistribution,
+            type(history[0].artifacts["bitstring_distribution"]),
+        )
+        np.testing.assert_array_equal(params, history[0].params)
+        assert pytest.approx(value_estimate, history[0].value)
+
+    @pytest.mark.parametrize(
+        "gradient_types, cf_factory",
+        [
+            (["finite_difference"], QCBMCostFunction),
+            ([finite_differences_gradient], create_QCBM_cost_function),
+        ],
+    )
+    def test_gradient(self, gradient_types, cf_factory, distance_measure_kwargs):
+        for gradient_type in gradient_types:
+            # Given
+            try:
+                cost_function = cf_factory(
+                    ansatz,
+                    backend,
+                    n_samples,
+                    **distance_measure_kwargs,
+                    target_bitstring_distribution=target_bitstring_distribution,
+                    gradient_type=gradient_type,
+                )
+            except TypeError:
+                cost_function = cf_factory(
+                    ansatz,
+                    backend,
+                    n_samples,
+                    **distance_measure_kwargs,
+                    target_bitstring_distribution=target_bitstring_distribution,
+                    gradient_function=gradient_type,
                 )
 
-                params = np.array([0, 0, 0, 0])
+            params = np.array([0, 0, 0, 0])
 
-                # When
-                value_estimate = cost_function(params)
+            # When
+            gradient = cost_function.gradient(params)
 
-                # Then
-                self.assertEqual(type(value_estimate), ValueEstimate)
-                assert isinstance(value_estimate.value, (np.floating, float))
+            # Then
+            assert pytest.approx(len(params), len(gradient))
+            for gradient_val in gradient:
+                assert pytest.approx(np.float64, type(gradient_val))
 
-    def test_evaluate_history(self):
-        for distance_meas, distance_measure_params in param_list:
-            with self.subTest():
-                # Given
-                self.distance_measure = distance_meas
-                distance_measure_parameters = distance_measure_params
+    def test_error_raised_if_gradient_is_not_supported(self, distance_measure_kwargs):
+        # Given
+        gradient_type = "UNSUPPORTED GRADIENT TYPE"
 
-                cost_function = QCBMCostFunction(
-                    self.ansatz,
-                    self.backend,
-                    self.n_samples,
-                    self.distance_measure,
-                    distance_measure_parameters,
-                    self.target_bitstring_distribution,
-                )
-
-                cost_function = recorder(cost_function)
-
-                params = np.array([0, 0, 0, 0])
-
-                # When
-                value_estimate = cost_function(params)
-                history = cost_function.history
-
-                # Then
-                self.assertEqual(len(history), 1)
-                self.assertEqual(
-                    BitstringDistribution,
-                    type(history[0].artifacts["bitstring_distribution"]),
-                )
-                np.testing.assert_array_equal(params, history[0].params)
-                self.assertEqual(value_estimate, history[0].value)
-
-    def test_gradient(self):
-        for distance_meas, distance_measure_params in param_list:
-            for gradient_type in self.gradient_types:
-                with self.subTest():
-                    # Given
-                    self.distance_measure = distance_meas
-                    distance_measure_parameters = distance_measure_params
-
-                    cost_function = QCBMCostFunction(
-                        self.ansatz,
-                        self.backend,
-                        self.n_samples,
-                        self.distance_measure,
-                        distance_measure_parameters,
-                        self.target_bitstring_distribution,
-                        gradient_type=gradient_type,
-                    )
-
-                    params = np.array([0, 0, 0, 0])
-
-                    # When
-                    gradient = cost_function.gradient(params)
-
-                    # Then
-                    self.assertEqual(len(params), len(gradient))
-                    for gradient_val in gradient:
-                        self.assertEqual(np.float64, type(gradient_val))
-
-    def test_error_raised_if_gradient_is_not_supported(self):
-        for distance_meas, distance_measure_params in param_list:
-            for gradient_type in self.gradient_types:
-                with self.subTest():
-                    # Given
-                    self.distance_measure = distance_meas
-                    distance_measure_parameters = distance_measure_params
-
-                    self.assertRaises(
-                        RuntimeError,
-                        lambda: QCBMCostFunction(
-                            self.ansatz,
-                            self.backend,
-                            self.n_samples,
-                            self.distance_measure,
-                            distance_measure_parameters,
-                            self.target_bitstring_distribution,
-                            gradient_type="UNSUPPORTED GRADIENT TYPE",
-                        ),
-                    )
+        # When/then
+        with pytest.raises(RuntimeError):
+            cost_function = (
+                QCBMCostFunction(
+                    ansatz,
+                    backend,
+                    n_samples,
+                    **distance_measure_kwargs,
+                    target_bitstring_distribution=target_bitstring_distribution,
+                    gradient_type=gradient_type,
+                ),
+            )
+            params = np.array([0, 0, 0, 0])
+            cost_function(params)
 
     def test_error_raised_if_target_distribution_and_ansatz_are_for_differing_number_of_qubits(
-        self,
+        self, cost_function_factory, distance_measure_kwargs
     ):
-        for distance_meas, distance_measure_params in param_list:
-            with self.subTest():
-                # Given
-                self.ansatz.number_of_qubits = 5
+        # Given
+        ansatz.number_of_qubits = 5
 
-                self.distance_measure = distance_meas
-                distance_measure_parameters = distance_measure_params
-
-                # When/Then
-                self.assertRaises(
-                    AssertionError,
-                    lambda: QCBMCostFunction(
-                        self.ansatz,
-                        self.backend,
-                        self.n_samples,
-                        self.distance_measure,
-                        distance_measure_parameters,
-                        self.target_bitstring_distribution,
-                    ),
-                )
+        # When/Then
+        with pytest.raises(AssertionError):
+            cost_function = (
+                cost_function_factory(
+                    ansatz,
+                    backend,
+                    n_samples,
+                    **distance_measure_kwargs,
+                    target_bitstring_distribution=target_bitstring_distribution,
+                ),
+            )
+            params = np.array([0, 0, 0, 0])
+            cost_function(params)

--- a/tests/zquantum/qcbm/cost_function_test.py
+++ b/tests/zquantum/qcbm/cost_function_test.py
@@ -102,41 +102,36 @@ class TestQCBMCostFunction:
         assert value_estimate == history[0].value
 
     @pytest.mark.parametrize(
-        "gradient_types, cf_factory",
+        "gradient_kwargs, cf_factory",
         [
-            (["finite_difference"], QCBMCostFunction),
-            ([finite_differences_gradient], create_QCBM_cost_function),
+            (
+                {"gradient_type": "finite_difference"},
+                QCBMCostFunction
+            ),
+            (
+                {"gradient_function": finite_differences_gradient},
+                create_QCBM_cost_function
+            ),
         ],
     )
-    def test_gradient(self, gradient_types, cf_factory, distance_measure_kwargs):
-        for gradient_type in gradient_types:
-            # Given
-            try:
-                cost_function = cf_factory(
-                    ansatz,
-                    backend,
-                    n_samples,
-                    **distance_measure_kwargs,
-                    target_bitstring_distribution=target_bitstring_distribution,
-                    gradient_type=gradient_type,
-                )
-            except TypeError:
-                cost_function = cf_factory(
-                    ansatz,
-                    backend,
-                    n_samples,
-                    **distance_measure_kwargs,
-                    target_bitstring_distribution=target_bitstring_distribution,
-                    gradient_function=gradient_type,
-                )
+    def test_gradient(self, gradient_kwargs, cf_factory, distance_measure_kwargs):
+        # Given
+        cost_function = cf_factory(
+            ansatz,
+            backend,
+            n_samples,
+            **distance_measure_kwargs,
+            target_bitstring_distribution=target_bitstring_distribution,
+            **gradient_kwargs
+        )
 
-            params = np.array([0, 0, 0, 0])
+        params = np.array([0, 0, 0, 0])
 
-            # When
-            gradient = cost_function.gradient(params)
+        # When
+        gradient = cost_function.gradient(params)
 
-            # Then
-            assert len(params) == len(gradient)
+        # Then
+        assert len(params) == len(gradient)
 
     def test_error_raised_if_gradient_is_not_supported(self, distance_measure_kwargs):
         # Given

--- a/tests/zquantum/qcbm/cost_function_test.py
+++ b/tests/zquantum/qcbm/cost_function_test.py
@@ -46,6 +46,18 @@ backend = create_object(
 n_samples = 1
 
 
+def test_QCBMCostFunction_raises_deprecation_warning():
+    with pytest.deprecated_call():
+        QCBMCostFunction(
+            ansatz,
+            backend,
+            n_samples,
+            distance_measure=compute_clipped_negative_log_likelihood,
+            distance_measure_parameters={"epsilon": 1e-6},
+            target_bitstring_distribution=target_bitstring_distribution
+        )
+
+
 class TestQCBMCostFunction:
     @pytest.fixture(params=[QCBMCostFunction, create_QCBM_cost_function])
     def cost_function_factory(self, request):

--- a/tests/zquantum/qcbm/cost_function_test.py
+++ b/tests/zquantum/qcbm/cost_function_test.py
@@ -78,25 +78,6 @@ class TestQCBMCostFunction:
     def distance_measure_kwargs(self, request):
         return request.param
 
-    def test_evaluate(self, cost_function_factory, distance_measure_kwargs):
-        # Given
-        cost_function = cost_function_factory(
-            ansatz,
-            backend,
-            n_samples,
-            **distance_measure_kwargs,
-            target_bitstring_distribution=target_bitstring_distribution,
-        )
-
-        params = np.array([0, 0, 0, 0])
-
-        # When
-        value_estimate = cost_function(params)
-
-        # Then
-        assert type(value_estimate) == ValueEstimate
-        assert isinstance(value_estimate.value, (np.floating, float))
-
     def test_evaluate_history(self, cost_function_factory, distance_measure_kwargs):
         # Given
         cost_function = cost_function_factory(
@@ -116,13 +97,9 @@ class TestQCBMCostFunction:
         history = cost_function.history
 
         # Then
-        assert pytest.approx(len(history), 1)
-        assert pytest.approx(
-            BitstringDistribution,
-            type(history[0].artifacts["bitstring_distribution"]),
-        )
+        assert len(history) == 1
         np.testing.assert_array_equal(params, history[0].params)
-        assert pytest.approx(value_estimate, history[0].value)
+        assert value_estimate == history[0].value
 
     @pytest.mark.parametrize(
         "gradient_types, cf_factory",
@@ -159,9 +136,7 @@ class TestQCBMCostFunction:
             gradient = cost_function.gradient(params)
 
             # Then
-            assert pytest.approx(len(params), len(gradient))
-            for gradient_val in gradient:
-                assert pytest.approx(np.float64, type(gradient_val))
+            assert len(params) == len(gradient)
 
     def test_error_raised_if_gradient_is_not_supported(self, distance_measure_kwargs):
         # Given

--- a/tests/zquantum/qcbm/cost_function_test.py
+++ b/tests/zquantum/qcbm/cost_function_test.py
@@ -54,7 +54,7 @@ def test_QCBMCostFunction_raises_deprecation_warning():
             n_samples,
             distance_measure=compute_clipped_negative_log_likelihood,
             distance_measure_parameters={"epsilon": 1e-6},
-            target_bitstring_distribution=target_bitstring_distribution
+            target_bitstring_distribution=target_bitstring_distribution,
         )
 
 
@@ -104,13 +104,10 @@ class TestQCBMCostFunction:
     @pytest.mark.parametrize(
         "gradient_kwargs, cf_factory",
         [
-            (
-                {"gradient_type": "finite_difference"},
-                QCBMCostFunction
-            ),
+            ({"gradient_type": "finite_difference"}, QCBMCostFunction),
             (
                 {"gradient_function": finite_differences_gradient},
-                create_QCBM_cost_function
+                create_QCBM_cost_function,
             ),
         ],
     )
@@ -122,7 +119,7 @@ class TestQCBMCostFunction:
             n_samples,
             **distance_measure_kwargs,
             target_bitstring_distribution=target_bitstring_distribution,
-            **gradient_kwargs
+            **gradient_kwargs,
         )
 
         params = np.array([0, 0, 0, 0])


### PR DESCRIPTION
Using a callable gradient argument for the QCBM cost function factory allows for easier maintenance / adding new gradients. Note that I had to refactor the cost function test a bit to use pytest fixtures to run the same tests through 2 cost functions